### PR TITLE
Add knob to enable/disable verbose debug logging

### DIFF
--- a/cmd/protoc-gen-go-patch/main.go
+++ b/cmd/protoc-gen-go-patch/main.go
@@ -21,6 +21,9 @@ func main() {
 		os.Exit(1)
 		return
 	}
+	if os.Getenv("PROTO_PATCH_DEBUG_LOGGING") != "1" {
+		log.SetOutput(ioutil.Discard)
+	}
 
 	var plugin string
 
@@ -29,8 +32,6 @@ func main() {
 			switch name {
 			case "plugin":
 				plugin = value
-			case "silent":
-				log.SetOutput(ioutil.Discard)
 			}
 			return nil // Ignore unknown params.
 		},
@@ -42,7 +43,6 @@ func main() {
 
 		// Strip our custom param(s).
 		patch.StripParam(gen.Request, "plugin")
-		patch.StripParam(gen.Request, "silent")
 
 		// Run the specified plugin and unmarshal the CodeGeneratorResponse.
 		res, err := patch.RunPlugin(plugin, gen.Request, nil)

--- a/cmd/protoc-gen-go-patch/main.go
+++ b/cmd/protoc-gen-go-patch/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -28,6 +29,8 @@ func main() {
 			switch name {
 			case "plugin":
 				plugin = value
+			case "silent":
+				log.SetOutput(ioutil.Discard)
 			}
 			return nil // Ignore unknown params.
 		},
@@ -39,6 +42,7 @@ func main() {
 
 		// Strip our custom param(s).
 		patch.StripParam(gen.Request, "plugin")
+		patch.StripParam(gen.Request, "silent")
 
 		// Run the specified plugin and unmarshal the CodeGeneratorResponse.
 		res, err := patch.RunPlugin(plugin, gen.Request, nil)

--- a/cmd/protoc-gen-go-patch/main.go
+++ b/cmd/protoc-gen-go-patch/main.go
@@ -21,7 +21,8 @@ func main() {
 		os.Exit(1)
 		return
 	}
-	if os.Getenv("PROTO_PATCH_DEBUG_LOGGING") != "1" {
+
+	if os.Getenv("PROTO_PATCH_DEBUG_LOGGING") == ""  {
 		log.SetOutput(ioutil.Discard)
 	}
 


### PR DESCRIPTION
Wanted to invert this and make it opt in logging, but I understand that
the plugin is a WIP.

```
--go-patch_out=plugin=go,silent=,paths=source_relative:.
```