### PR TITLE
Use concise option syntax

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [Unreleased]
 
 ### Added
-
+- Updated docs, examples, and tests to use concise option syntax instead of `{}` delimited options.
 ### Fixed
 
 ### Known Issues

--- a/README.md
+++ b/README.md
@@ -20,6 +20,26 @@ Patches are defined via an `Options` extension on messages, fields, `oneof` fiel
 import "patch/go.proto";
 
 message OldName {
+	option (go.message).name = 'NewName';
+	int id = 1 [(go.field).name = 'ID'];
+}
+
+enum Errors {
+	option (go.enum).name = 'ProtocolErrors';
+	INVALID = 1 [(go.value).name = 'ErrInvalid'];
+	NOT_FOUND = 2 [(go.value).name = 'ErrNotFound'];
+	TOO_FUN = 3 [(go.value).name = 'ErrTooFun'];
+}
+```
+
+#### Alternate Syntax
+
+Multiple options can be grouped together with a message bounded by `{}`:
+
+```proto
+import "patch/go.proto";
+
+message OldName {
 	option (go.message) = {name: 'NewName'};
 	int id = 1 [(go.field) = {name: 'ID'}];
 }
@@ -33,6 +53,17 @@ enum Errors {
 ```
 
 ### Struct Tags
+
+```proto
+message ToDo {
+	int32 id = 1 [(go.field).name: 'ID', tags: 'xml:"id,attr"'];
+	string description = 2 [(go.field).tags: 'xml:"desc"'];
+}
+```
+
+#### Alternate Syntax
+
+Multiple options can be grouped together with a message bounded by `{}`:
 
 ```proto
 message ToDo {

--- a/patch/patcher.go
+++ b/patch/patcher.go
@@ -21,13 +21,13 @@ import (
 )
 
 // Patcher patches a set of generated Go Protobuf files with additional features:
-// - go_name (Field option) overrides the name of a synthesized struct field and getters.
-// - go_tags (Field option) lets you add additional struct tags to a field.
-// - go_oneof_name (Oneof option) overrides the name of a oneof field, including wrapper types and getters.
-// - go_oneof_tags (Oneof option) lets you specify additional struct tags on a oneof field.
-// - go_message_name (Message option) overrides the name of the synthesized struct.
-// - go_enum_name (Enum option) overrides the name of an enum type.
-// - go_value_name (EnumValue option) overrides the name of an enum const.
+// - (go.message).name overrides the name of a message’s synthesized struct.
+// - (go.field).name overrides the name of a synthesized struct field and getters.
+// - (go.field).tags lets you add additional struct tags to a field.
+// - (go.oneof).name overrides the name of a oneof field, including wrapper types and getters.
+// - (go.oneof).tags lets you specify additional struct tags on a oneof field.
+// - (go.enum).name overrides the name of an enum type.
+// - (go.value).name overrides the name of an enum value.
 type Patcher struct {
 	gen            *protogen.Plugin
 	fset           *token.FileSet

--- a/tests/enum/enum_renames.proto
+++ b/tests/enum/enum_renames.proto
@@ -9,9 +9,7 @@ import "patch/go.proto";
 option go_package = "github.com/alta/protopatch/tests/enum";
 
 enum OriginalEnum {
-	option (go.enum) = {
-		name: 'RenamedEnum'
-	};
+	option (go.enum).name = 'RenamedEnum';
 	INVALID = 0;
 	A = 1;
 	B = 2;
@@ -19,19 +17,17 @@ enum OriginalEnum {
 }
 
 enum EnumWithRenamedValue {
-	ORIGINAL_VALUE = 0 [(go.value) = {name: 'RenamedValue'}];
+	ORIGINAL_VALUE = 0 [(go.value).name = 'RenamedValue'];
 	ONE = 1;
 }
 
 message MessageWithRenamedEnum {
 	enum InnerEnum {
-		option (go.enum) = {
-			name: 'RenamedNestedEnum'
-		};
-		INVALID = 0 [(go.value) = {name: 'RenamedValueInvalid'}];
-		A = 1 [(go.value) = {name: 'RenamedValueA'}];
-		B = 2 [(go.value) = {name: 'RenamedValueB'}];
-		C = 3 [(go.value) = {name: 'RenamedValueC'}];
+		option (go.enum).name = 'RenamedNestedEnum';
+		INVALID = 0 [(go.value).name = 'RenamedValueInvalid'];
+		A = 1 [(go.value).name = 'RenamedValueA'];
+		B = 2 [(go.value).name = 'RenamedValueB'];
+		C = 3 [(go.value).name = 'RenamedValueC'];
 	}
 	InnerEnum inner = 1;
 }

--- a/tests/enum/enum_stringer.proto
+++ b/tests/enum/enum_stringer.proto
@@ -9,9 +9,7 @@ import "patch/go.proto";
 option go_package = "github.com/alta/protopatch/tests/enum";
 
 enum CustomStringerEnum {
-	option (go.enum) = {
-		stringer_name: 'OrigString'
-	};
+	option (go.enum).stringer_name = 'OrigString';
 	CUSTOM_STRINGER_INVALID = 0;
 	CUSTOM_STRINGER_A = 1;
 	CUSTOM_STRINGER_B = 2;

--- a/tests/message/message_renames.proto
+++ b/tests/message/message_renames.proto
@@ -7,15 +7,11 @@ import "patch/go.proto";
 option go_package = "github.com/alta/protopatch/tests/message";
 
 message OriginalMessage {
-	option (go.message) = {
-		name: 'RenamedMessage'
-	};
+	option (go.message).name = 'RenamedMessage';
 }
 
 message OriginalOneofMessage {
-	option (go.message) = {
-		name: 'RenamedOneofMessage'
-	};
+	option (go.message).name = 'RenamedOneofMessage';
 	oneof contents {
 		int32 id = 1;
 		string name = 2;
@@ -23,22 +19,18 @@ message OriginalOneofMessage {
 }
 
 message OriginalOuterMessage {
-	option (go.message) = {
-		name: 'RenamedOuterMessage'
-	};
+	option (go.message).name = 'RenamedOuterMessage';
 	message InnerMessage {}
 	InnerMessage inner = 1;
 }
 
 message OuterMessageWithRenamedInnerMessage {
 	message InnerMessage {
-		option (go.message) = {
-			name: 'RenamedInnerMessage'
-		};
+		option (go.message).name = 'RenamedInnerMessage';
 	}
 	InnerMessage inner = 1;
 }
 
 message MessageWithRenamedField {
-	int32 id = 1 [(go.field) = {name: 'ID'}];
+	int32 id = 1 [(go.field).name = 'ID'];
 }

--- a/tests/message/struct_tags.proto
+++ b/tests/message/struct_tags.proto
@@ -7,11 +7,11 @@ import "patch/go.proto";
 option go_package = "github.com/alta/protopatch/tests/message";
 
 message MessageWithTags {
-	string value = 1 [(go.field) = {tags: 'test:"value"'}];
+	string value = 1 [(go.field).tags = 'test:"value"'];
 }
 
 message OuterMessageWithTags {
 	message InnerMessage {
-		string value = 1 [(go.field) = {tags: 'test:"value"'}];
+		string value = 1 [(go.field).tags = 'test:"value"'];
 	}
 }


### PR DESCRIPTION
## From:

```proto
message ToDo {
	int32 id = 1 [(go.field) = {name: 'ID', tags: 'xml:"id,attr"'}];
	string description = 2 [(go.field) = {tags: 'xml:"desc"'}];
}
```
# To:

```proto
message ToDo {
	int32 id = 1 [(go.field).name: 'ID', tags: 'xml:"id,attr"'];
	string description = 2 [(go.field).tags: 'xml:"desc"'];
}
```