### PR TITLE
README: Fix Usage doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,13 @@ Patch `protoc` plugin output with Go-specific features. The `protoc-gen-go-patch
 
 `go install github.com/alta/protopatch/cmd/protoc-gen-go-patch`
 
+## Update Go module
+
+```shell
+go get google.golang.org/protobuf
+go get github.com/alta/protopatch
+```
+
 ## Usage
 
 After installing `protoc-gen-go-patch`, use it by specifying it with a `--go-patch_out=...` argument to `protoc`:
@@ -15,8 +22,8 @@ After installing `protoc-gen-go-patch`, use it by specifying it with a `--go-pat
 ```shell
 protoc \
 	-I . \
-	-I `go list -m -f {{.Dir}} github.com/alta/protopatch@latest` \
-	-I `go list -m -f {{.Dir}} google.golang.org/protobuf@latest` \
+	-I `go list -m -f {{.Dir}} github.com/alta/protopatch` \
+	-I `go list -m -f {{.Dir}} google.golang.org/protobuf` \
 	--go-patch_out=plugin=go,paths=source_relative:. \
 	--go-patch_out=plugin=go-grpc,paths=source_relative:. \
 	*.proto

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Patch `protoc` plugin output with Go-specific features. The `protoc-gen-go-patch
 
 ## Install
 
-`go install github.com/alta/protopatch/cmd/protoc-gen-go-patch`
+`go install github.com/alta/protopatch/cmd/protoc-gen-go-patch@latest`
 
 ## Update Go module
 

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ After installing `protoc-gen-go-patch`, use it by specifying it with a `--go-pat
 ```shell
 protoc \
 	-I . \
-	-I `go list -m -f {{.Dir}} github.com/alta/protopatch` \
+	-I `go list -m -f {{.Dir}} github.com/alta/protopatch@latest` \
 	-I `go list -m -f {{.Dir}} google.golang.org/protobuf` \
 	--go-patch_out=plugin=go,paths=source_relative:. \
 	--go-patch_out=plugin=go-grpc,paths=source_relative:. \

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ After installing `protoc-gen-go-patch`, use it by specifying it with a `--go-pat
 protoc \
 	-I . \
 	-I `go list -m -f {{.Dir}} github.com/alta/protopatch@latest` \
-	-I `go list -m -f {{.Dir}} google.golang.org/protobuf` \
+	-I `go list -m -f {{.Dir}} google.golang.org/protobuf@latest` \
 	--go-patch_out=plugin=go,paths=source_relative:. \
 	--go-patch_out=plugin=go-grpc,paths=source_relative:. \
 	*.proto


### PR DESCRIPTION
When I run 
```shell
protoc \
	-I . \
	-I `go list -m -f {{.Dir}} github.com/alta/protopatch` \
	-I `go list -m -f {{.Dir}} google.golang.org/protobuf` \
	--go-patch_out=plugin=go,paths=source_relative:. \
	--go-patch_out=plugin=go-grpc,paths=source_relative:. \
	*.proto
```
it produce a error  message:
```
go list -m: module github.com/alta/protopatch: not a known dependency
````

There are two way fix this:
1. Specific version. `go list -m -f {{.Dir}} github.com/alta/protopatch@latest`
2. Run `go get github.com/alta/protopatch` to update go mod  before run `protoc`.